### PR TITLE
tarfs: Normalize paths

### DIFF
--- a/tarfs.go
+++ b/tarfs.go
@@ -9,10 +9,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
-
 
 // New returns an http.FileSystem that holds all the files in the tar,
 // It reads the whole archive from the Reader. It is the caller's responsibility to call Close on the Reader when done.
@@ -35,7 +35,10 @@ func New(tarstream io.Reader) (http.FileSystem, error) {
 			return nil, err
 		}
 
-		tarfs.files[hdr.Name] = file{data: data, fi: hdr.FileInfo()}
+		tarfs.files[path.Join("/", hdr.Name)] = file{
+			data: data,
+			fi:   hdr.FileInfo(),
+		}
 	}
 	return &tarfs, nil
 }
@@ -57,7 +60,7 @@ func (tf *tarfs) Open(name string) (http.File, error) {
 		strings.Contains(name, "\x00") {
 		return nil, errors.New("http: invalid character in file path")
 	}
-	f, ok := tf.files[name]
+	f, ok := tf.files[path.Join("/", name)]
 	if !ok {
 		return nil, os.ErrNotExist
 	}

--- a/tarfs_test.go
+++ b/tarfs_test.go
@@ -18,11 +18,43 @@ func TestOpen(t *testing.T) {
 
 	// Add some files to the archive.
 	var files = []struct {
-		Name, Body string
+		Name        string
+		Body        string
+		AccessNames []string
 	}{
-		{"readme.txt", "This archive contains some text files."},
-		{"gopher.txt", "Gopher names:\nGeorge\nGeoffrey\nGonzo"},
-		{"todo.txt", "Get animal handling licence."},
+		{
+			Name: "readme.txt",
+			Body: "This archive contains some text files.",
+			AccessNames: []string{
+				"readme.txt",
+				"/readme.txt",
+				"./readme.txt",
+				"././readme.txt",
+				"../readme.txt",
+			},
+		},
+		{
+			Name: "/gopher.txt",
+			Body: "Gopher names:\nGeorge\nGeoffrey\nGonzo",
+			AccessNames: []string{
+				"gopher.txt",
+				"/gopher.txt",
+				"./gopher.txt",
+				"././gopher.txt",
+				"../gopher.txt",
+			},
+		},
+		{
+			Name: "./todo.txt",
+			Body: "Get animal handling licence.",
+			AccessNames: []string{
+				"todo.txt",
+				"/todo.txt",
+				"./todo.txt",
+				"././todo.txt",
+				"../todo.txt",
+			},
+		},
 	}
 	for _, file := range files {
 		hdr := &tar.Header{
@@ -48,23 +80,25 @@ func TestOpen(t *testing.T) {
 	}
 
 	for _, file := range files {
-		f, err := fs.Open(file.Name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		content, _ := ioutil.ReadAll(f)
-		if string(content) != file.Body {
-			t.Fatalf("For '%s'\nExpected:\n%s\nGot:\n%s\n", file.Name, file.Body, content)
-		}
+		for _, path := range file.AccessNames {
+			f, err := fs.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			content, _ := ioutil.ReadAll(f)
+			if string(content) != file.Body {
+				t.Fatalf("For '%s'\nExpected:\n%s\nGot:\n%s\n", file.Name, file.Body, content)
+			}
 
-		var (
-			s, _ = f.Stat()
-			size = int64(len(file.Body))
-			got  = s.Size()
-		)
+			var (
+				s, _ = f.Stat()
+				size = int64(len(file.Body))
+				got  = s.Size()
+			)
 
-		if size != got {
-			t.Fatalf("For '%s'\nExpected Size:\n%v\nGot:\n%v\n", file.Name, size, got)
+			if size != got {
+				t.Fatalf("For '%s'\nExpected Size:\n%v\nGot:\n%v\n", file.Name, size, got)
+			}
 		}
 	}
 }


### PR DESCRIPTION
In `New`, and then again in `Open` before we attempt to lookup the path in the files map.  This allows us to use tarballs generated with GNU's tar, which prefixes files with `./`:

```
$ tar --version | head -n1
tar (GNU tar) 1.29
$ mkdir a
$ cd a
$ touch readme.txt
$ tar -cvf ../test.tar .
./
./readme.txt
$ tar -tf ../test.tar
./
./readme.txt
```

When using that tarball for file URIs, we want `file:///readme.txt` to resolve to that file, regardless of whether it's in the tarball as `readme.txt`, `/readme.txt`, `./readme.txt`, etc.